### PR TITLE
Add config for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+dist: bionic
+
+language: java
+
+jdk:
+  - openjdk8
+  - openjdk11
+
+cache:
+  directories:
+    - '$HOME/.m2/repository'


### PR DESCRIPTION
Simple config for running CI builds on Travis CI. The build checks that the project compiles on OpenJDK 8 and 11 and all tests pass.