### PR TITLE
Move pushing containers to the deploy phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 User Language Support for the Kotlin Programming Language
 
+## Install the Kotlin Support Library to the local Maven repository
+
+`mvn install -pl cloudstate-kotlin-support`
+
+## Examples: build and push container images to a container registry
+
+`mvn deploy -pl examples/kotlin-chat`
+
+`mvn deploy -pl examples/kotlin-pingpong`
+
+`mvn deploy -pl examples/shopping-cart`
+
 ## EventSourcing example of use
 
 ### Define your proto

--- a/examples/kotlin-chat/pom.xml
+++ b/examples/kotlin-chat/pom.xml
@@ -156,7 +156,7 @@
                 <version>1.7.0</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>deploy</phase>
                         <goals>
                             <goal>build</goal>
                         </goals>
@@ -180,6 +180,13 @@
                             <port>8080</port>
                         </ports>
                     </container>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/kotlin-pingpong/pom.xml
+++ b/examples/kotlin-pingpong/pom.xml
@@ -171,7 +171,7 @@
                 <version>1.7.0</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>deploy</phase>
                         <goals>
                             <goal>build</goal>
                         </goals>
@@ -198,6 +198,13 @@
                             <port>8080</port>
                         </ports>
                     </container>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/shopping-cart/pom.xml
+++ b/examples/shopping-cart/pom.xml
@@ -172,7 +172,7 @@
                 <version>1.7.0</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>deploy</phase>
                         <goals>
                             <goal>build</goal>
                         </goals>
@@ -199,6 +199,13 @@
                             <port>8080</port>
                         </ports>
                     </container>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
According to [the Maven guide](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#a-build-lifecycle-is-made-up-of-phases), copying of the final package to the remote repository should happen at the `deploy` phase.
Fixes Travis CI build failure (see #16).