### PR TITLE
Rename IntegrationTests to IntegrationTest

### DIFF
--- a/cloudstate-kotlin-support/src/test/kotlin/io/cloudstate/kotlinsupport/tests/IntegrationTest.kt
+++ b/cloudstate-kotlin-support/src/test/kotlin/io/cloudstate/kotlinsupport/tests/IntegrationTest.kt
@@ -15,7 +15,7 @@ import org.testcontainers.containers.wait.strategy.Wait
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 
-class IntegrationTests {
+class IntegrationTest {
     private val log = logger()
 
     private val sys: ActorSystem = ActorSystem.create("GrpcTestClientSys")


### PR DESCRIPTION
Allow `maven-surefire-plugin` to run `IntegrationTest` (see #20).