### PR TITLE
doc: Rename final jar name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ allprojects {
     configurations.all {
         resolutionStrategy {
             dependencySubstitution {
-                substitute(module("io.cloudstate:cloudstate-kotlin-support"))
+                substitute(module("io.cloudstate:kotlin-support"))
                         .with(project(":cloudstate-kotlin-support"))
             }
         }

--- a/examples/kotlin-chat/build.gradle.kts
+++ b/examples/kotlin-chat/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    implementation("io.cloudstate:cloudstate-kotlin-support:0.4.3")
+    implementation("io.cloudstate:kotlin-support:0.4.3")
     implementation("ch.qos.logback:logback-classic:1.2.3")
     testImplementation(kotlin("test"))
     testImplementation(kotlin("test-junit"))

--- a/examples/kotlin-pingpong/build.gradle.kts
+++ b/examples/kotlin-pingpong/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    implementation("io.cloudstate:cloudstate-kotlin-support:0.4.3")
+    implementation("io.cloudstate:kotlin-support:0.4.3")
     implementation("com.google.api.grpc:proto-google-common-protos:1.17.0")
     implementation("ch.qos.logback:logback-classic:1.2.3")
     testImplementation(kotlin("test"))

--- a/examples/shopping-cart/build.gradle.kts
+++ b/examples/shopping-cart/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    implementation("io.cloudstate:cloudstate-kotlin-support:0.4.3")
+    implementation("io.cloudstate:kotlin-support:0.4.3")
     implementation("com.google.api.grpc:proto-google-common-protos:1.17.0")
     implementation("ch.qos.logback:logback-classic:1.2.3")
     testImplementation(kotlin("test"))


### PR DESCRIPTION
The jar name has been changed from cloudstate-kotlin-support to
kotlin-support as explained in the issue.

The commit changes the name in all the files needed.

Fix: #29