### PR TITLE
Remole all lock files and gradle-kotlin-dsl dirs from Travis CI cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,10 @@ jdk:
   - openjdk11
 
 before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -f  $HOME/.gradle/caches/*/*.lock
+  - rm -f  $HOME/.gradle/caches/*/*/*.lock
   - rm -fr $HOME/.gradle/caches/journal-1/
-  - rm -f  $HOME/.gradle/caches/*/fileContent/fileContent.lock
-  - rm -f  $HOME/.gradle/caches/*/generated-gradle-jars/generated-gradle-jars.lock
-  - rm -f  $HOME/.gradle/caches/*/javaCompile/javaCompile.lock
-  - rm -f  $HOME/.gradle/caches/*/gradle-kotlin-dsl/
+  - rm -fr $HOME/.gradle/caches/*/gradle-kotlin-dsl*
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
   - rm -fr $HOME/.gradle/caches/*/fileHashes/
 cache:


### PR DESCRIPTION
Yet another attempt to avoid building new Travis CI cache on every build.