### PR TITLE
Fix CRDT reflection support

### DIFF
--- a/cloudstate-kotlin-support/src/main/kotlin/io/cloudstate/kotlinsupport/CloudstateRunner.kt
+++ b/cloudstate-kotlin-support/src/main/kotlin/io/cloudstate/kotlinsupport/CloudstateRunner.kt
@@ -40,7 +40,7 @@ class CloudStateRunner(private val initializer: CloudStateInitializer) {
                     val clazz: Class<*>? = descriptor.transcoder!!.transcode()
 
                     engine.registerCrdtEntity(
-                            AnnotationBasedCrdtSupport(descriptor.serviceClass!!::class.java, anySupport!!, descriptor.descriptor!!),
+                            AnnotationBasedCrdtSupport(descriptor.serviceClass!!.java, anySupport!!, descriptor.descriptor!!),
                             descriptor.descriptor,
                             *descriptor.additionalDescriptors.toTypedArray())
                 }

--- a/examples/kotlin-chat/src/main/kotlin/io/cloudstate/examples/chat/presence/PresenceEntity.kt
+++ b/examples/kotlin-chat/src/main/kotlin/io/cloudstate/examples/chat/presence/PresenceEntity.kt
@@ -8,7 +8,6 @@ import io.cloudstate.javasupport.EntityId
 import io.cloudstate.javasupport.crdt.*
 
 import io.cloudstate.kotlinsupport.annotations.crdt.CrdtEntity
-import io.cloudstate.kotlinsupport.annotations.crdt.CommandHandler
 
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean


### PR DESCRIPTION
Should resolve #46.

Rather than being passed the java class for the entity, it was being passed the java class for kotlin's `KClassImpl`, which has a single `java.lang.Class` parameter for its constructor. Passing the correct java class seems to work fine.

And the chat example needs to use the java-support CommandHandler annotation, since the java-support `AnnotationBasedCrdtSupport` is being used, and the `KotlinAnnotationBasedCrdt` is not implemented yet.